### PR TITLE
refactor: Align health endpoint URL with API documentation

### DIFF
--- a/backend/api/tests/test_health.py
+++ b/backend/api/tests/test_health.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 class HealthCheckTestCase(TestCase):
 
     def test_health_check_returns_ok_status(self):
-        response = self.client.get(reverse("health-check"))
+        response = self.client.get(reverse("health"))
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response["Content-Type"], "application/json")

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("health-check/", views.health_check, name="health-check"),
+    path("health/", views.health_check, name="health"),
 ]


### PR DESCRIPTION
- Change URL path from 'health-check/' to 'health/'
- Update URL name for consistency
- Modify test to use updated URL name
- Ensures consistency between implementation and documentation

This PR aligns the health endpoint path with our API documentation standard, changing from 'health-check/' to 'health/'. This ensures consistency between our implementation and published API contracts.

Tests have been updated to match the new URL name, and manual testing confirms the endpoint works correctly at the new path.