### PR TITLE
docs: update documentation to include DJANGO_ENV=test usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,9 @@ python manage.py runserver
 # Run tests (always specify the test module path)
 python manage.py test api.tests.<test_module>
 
+# Run tests with test-specific settings
+DJANGO_ENV=test python manage.py test api.tests.<test_module>
+
 # Format code
 black .
 isort .
@@ -54,6 +57,9 @@ docker compose up -d
 
 # Run tests in Docker
 docker compose exec backend python manage.py test api.tests.<test_module>
+
+# Run tests with test-specific settings in Docker
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.<test_module>"
 
 # Stop Docker when done
 docker compose down

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ A modern, type-safe web application for visualizing bird locations from the xeno
    # Run tests to verify
    docker compose exec backend python manage.py test
 
+   # Run tests with test-specific settings
+   docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test"
+
    # Stop Docker when done
    docker compose down
    ```

--- a/docs/backend/setup/concepts/development-approaches.md
+++ b/docs/backend/setup/concepts/development-approaches.md
@@ -73,14 +73,30 @@ docker compose build
 ## TDD Workflow in Hybrid Environment
 
 1. Write tests in local environment
-2. Run tests locally using `python manage.py test api.tests.<test_module>`
+2. Run tests locally using regular or test-specific settings:
+
+   ```bash
+   # Regular development settings
+   python manage.py test api.tests.<test_module>
+
+   # Test-specific settings
+   DJANGO_ENV=test python manage.py test api.tests.<test_module>
+   ```
+
 3. Implement features locally
 4. Run tests locally again for rapid feedback cycles
 5. Verify in Docker before committing:
+
    ```bash
    docker compose up -d
+
+   # Regular development settings
    docker compose exec backend python manage.py test api.tests.<test_module>
+
+   # Test-specific settings
+   docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.<test_module>"
    ```
+
 6. Create pull request with all tests passing in both environments
 7. CI/CD pipeline runs tests in Docker
 

--- a/docs/backend/setup/details/step2-environment-configuration.md
+++ b/docs/backend/setup/details/step2-environment-configuration.md
@@ -88,7 +88,7 @@ Create a file named `.env.sample` in the project root directory with the followi
 
 ```
 # Django settings
-DJANGO_ENV=local
+DJANGO_ENV=local  # Options: local, test, production
 DJANGO_SETTINGS_MODULE=hellobirdie.settings.local
 DJANGO_SECRET_KEY=your-secret-key-here
 DJANGO_DEBUG=True

--- a/docs/backend/setup/details/step4-implementing-first-feature.md
+++ b/docs/backend/setup/details/step4-implementing-first-feature.md
@@ -5,6 +5,7 @@ This guide provides detailed instructions for implementing the health check endp
 ## Why Start with a Health Check?
 
 A health check endpoint is an ideal first feature because:
+
 - It's simple to implement but provides immediate value
 - It establishes the basic API structure and testing patterns
 - It helps verify that your entire stack (Django, database, web server) is functioning correctly
@@ -42,7 +43,11 @@ class HealthCheckTestCase(TestCase):
 Run the test to verify it fails (expected at this stage):
 
 ```bash
+# Using default settings
 python manage.py test api.tests.test_health
+
+# Or using test-specific settings
+DJANGO_ENV=test python manage.py test api.tests.test_health
 ```
 
 You should see an error about 'health-check' not being a valid view or pattern name.
@@ -92,7 +97,11 @@ urlpatterns = [
 Run the test again to verify it now passes:
 
 ```bash
+# Using default settings
 python manage.py test api.tests.test_health
+
+# Or using test-specific settings
+DJANGO_ENV=test python manage.py test api.tests.test_health
 ```
 
 You should see that the test passes successfully.

--- a/docs/backend/setup/details/step6-database-configuration.md
+++ b/docs/backend/setup/details/step6-database-configuration.md
@@ -68,6 +68,9 @@ Let's verify that our database configuration works correctly in the local enviro
 # Always specify the test module path to avoid import errors
 python manage.py test api.tests.<test_module>
 
+# To use test-specific settings
+DJANGO_ENV=test python manage.py test api.tests.<test_module>
+
 # Example: Test the health check endpoint
 python manage.py test api.tests.test_health
 
@@ -91,6 +94,9 @@ docker compose exec backend python manage.py migrate
 # Run tests in Docker
 # Always specify the test module path to avoid import errors
 docker compose exec backend python manage.py test api.tests.<test_module>
+
+# To use test-specific settings in Docker
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.<test_module>"
 
 # Example: Test the health check endpoint
 docker compose exec backend python manage.py test api.tests.test_health

--- a/docs/backend/setup/guides/feature-setup-guide.md
+++ b/docs/backend/setup/guides/feature-setup-guide.md
@@ -37,11 +37,22 @@ This guide builds upon the backend setup and provides detailed steps for impleme
   # Local verification
   source .venv/bin/activate
   cd backend
+
+  # Using default development settings
   python manage.py test api.tests
+
+  # Using test-specific settings
+  DJANGO_ENV=test python manage.py test api.tests
 
   # Docker verification
   docker compose up -d
+
+  # Using default development settings
   docker compose exec backend python manage.py test api.tests
+
+  # Using test-specific settings
+  docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests"
+
   docker compose down
   ```
 

--- a/docs/backend/setup/hybrid-backend-setup-guide.md
+++ b/docs/backend/setup/hybrid-backend-setup-guide.md
@@ -268,14 +268,19 @@ docker compose exec backend python manage.py test api.tests.<test_module>
 # Example: Test the health check endpoint
 docker compose exec backend python manage.py test api.tests.test_health
 
-# Run pytest tests
+# Run pytest tests with default settings
 docker compose exec backend pytest
+
+# Run tests with explicit test settings
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test"
 
 # Run with coverage
 docker compose exec backend pytest --cov=api
 
 # Shut down containers
 docker compose down
+
+> **Note:** Use `DJANGO_ENV=test` when running comprehensive test suites or when you need test-specific optimizations. See [TDD Testing Strategy](./tdd-testing-strategy.md#split-settings-and-tdd) for details.
 
 > **Note:** For Docker Compose V1 (older versions), use `docker-compose` instead of `docker compose`. The project requires Docker Compose 2.33.0 or newer, which uses the V2 syntax without the hyphen.
 ```

--- a/docs/backend/setup/tdd-testing-strategy.md
+++ b/docs/backend/setup/tdd-testing-strategy.md
@@ -113,23 +113,42 @@ docker compose exec backend pytest --cov=api
 
 ## Split Settings and TDD
 
-The test.py settings file provides several TDD benefits:
+The project uses a split settings approach with environment-specific configuration files. For testing, we have a dedicated `test.py` settings file that provides several TDD benefits:
+
+### Setting the Test Environment
+
+```bash
+# Run tests with test settings (local development)
+DJANGO_ENV=test python -m pytest
+
+# Run tests with test settings (Docker)
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test"
+```
+
+### When to Use Test Settings
+
+- **Comprehensive test suites**: When running a full test suite with database-intensive tests
+- **Testing environment-specific features**: For features that behave differently in test vs. production
+- **Pre-deployment verification**: To ensure tests pass in a production-like environment
+- **CI/CD pipeline simulation**: When you want to match the CI environment locally
+
+### Benefits of Test Settings
 
 1. **Reliability**:
 
    - Uses dedicated PostgreSQL test database
-   - Simpler password hashing
+   - Simpler password hashing for faster tests
    - Disabled non-essential middleware
 
 2. **Isolation**:
 
-   - Separate test database
-   - Disabled caching
+   - Separate test database prevents polluting development data
+   - Disabled caching for predictable results
    - Controlled environment variables
 
 3. **Reproducibility**:
    - Same settings for all developers
-   - Consistent test behavior
+   - Consistent test behavior across environments
 
 ## TDD Best Practices for HelloBirdie
 

--- a/docs/project/development-environment.md
+++ b/docs/project/development-environment.md
@@ -165,7 +165,7 @@ Required variables in `.env`:
 
 ```plaintext
 # Django settings
-DJANGO_ENV=local
+DJANGO_ENV=local  # Options: local, test, production
 DJANGO_SETTINGS_MODULE=hellobirdie.settings.local
 DJANGO_SECRET_KEY=your-secret-key-here
 DJANGO_DEBUG=True  # Set to False in production

--- a/docs/project/docker-guide.md
+++ b/docs/project/docker-guide.md
@@ -230,17 +230,22 @@ npm run dev
 
 # Run backend tests
 # Always specify the test module path to avoid import errors
+
+# Using default development settings
 docker compose exec backend python manage.py test api.tests.<test_module>
+
+# Using test-specific settings
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.<test_module>"
 
 # Examples:
 # Test a specific module
 docker compose exec backend python manage.py test api.tests.test_health
 
-# Test a specific test class
-docker compose exec backend python manage.py test api.tests.test_health:HealthCheckTestCase
+# Test a specific class with test-specific settings
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.test_health:HealthCheckTestCase"
 
-# Test a specific test method
-docker compose exec backend python manage.py test api.tests.test_health:HealthCheckTestCase.test_health_check_returns_ok_status
+# Test a specific method with test-specific settings
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.test_health:HealthCheckTestCase.test_health_check_returns_ok_status"
 
 # Format backend code
 docker compose exec backend black .

--- a/docs/project/hybrid_workflow_guide.md
+++ b/docs/project/hybrid_workflow_guide.md
@@ -36,6 +36,9 @@ python manage.py test api.tests.<test_module>
 # Example: Test the health check endpoint
 python manage.py test api.tests.test_health
 
+# Run tests with test-specific settings
+DJANGO_ENV=test python manage.py test api.tests.<test_module>
+
 # Create migrations
 python manage.py makemigrations
 
@@ -64,6 +67,9 @@ docker compose exec backend python manage.py test api.tests.<test_module>
 
 # Example: Test the health check endpoint
 docker compose exec backend python manage.py test api.tests.test_health
+
+# Run tests with test-specific settings in Docker
+docker compose exec backend bash -c "DJANGO_ENV=test python manage.py test api.tests.<test_module>"
 
 # Run migrations in Docker
 docker compose exec backend python manage.py migrate


### PR DESCRIPTION
- Add instructions for using DJANGO_ENV=test in both local and Docker environments
- Update testing examples across all documentation files
- Ensure consistent instructions for test environment configuration
- Support hybrid development workflow with environment-specific settings