### PR TITLE
Refactor/align environment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,15 @@ media/
 .venv/
 venv/
 ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment variables
+.env
+backend/.env
+.env.sample
+backend/.env.sample

--- a/backend/api/tests/test_health.py
+++ b/backend/api/tests/test_health.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 class HealthCheckTestCase(TestCase):
 
     def test_health_check_returns_ok_status(self):
-        response = self.client.get(reverse("health"))
+        response = self.client.get(reverse("health-check"))
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response["Content-Type"], "application/json")

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("health/", views.health_check, name="health"),
+    path("health-check/", views.health_check, name="health-check"),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,11 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DJANGO_ENV=development
-      - DJANGO_SETTINGS_MODULE=hellobirdie.settings.local
-      - ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
-      - DATABASE_URL=postgres://postgres:postgres@db:5432/hellobirdie
-      - IN_DOCKER=True
-      - TZ=UTC
+      - DJANGO_ENV=local # Must match the environment name used in settings/__init__.py
+      # Do not set DJANGO_SETTINGS_MODULE here - allow __init__.py to handle it based on DJANGO_ENV
+      - IN_DOCKER=True # Helps settings determine correct database host
+    env_file:
+      - ./backend/.env # Load backend-specific environment variables
     depends_on:
       - db
 

--- a/docs/backend/setup/details/step1-project-structure-setup.md
+++ b/docs/backend/setup/details/step1-project-structure-setup.md
@@ -110,10 +110,9 @@ ENV/
 
 # Environment variables
 .env
-.env.local
-.env.development
-.env.test
-.env.production
+backend/.env
+.env.sample
+backend/.env.sample
 ```
 
 ### If Merging with an Existing .gitignore

--- a/docs/backend/setup/details/step2-environment-configuration.md
+++ b/docs/backend/setup/details/step2-environment-configuration.md
@@ -180,9 +180,9 @@ if [ -f backend/.env ]; then
   echo "You can use the following command to see what's in the existing file:"
   echo "cat backend/.env"
   echo "And compare with the sample:"
-  echo "cat .env.backend.sample"
+  echo "cat backend/.env.backend.sample"
 else
-  cp .env.backend.sample backend/.env
+  cp backend/.env.backend.sample backend/.env
   echo "Backend .env file created successfully."
 fi
 ```

--- a/docs/backend/setup/details/step2-environment-configuration.md
+++ b/docs/backend/setup/details/step2-environment-configuration.md
@@ -173,7 +173,7 @@ Now, let's create the backend-specific `.env` file:
 
 ```bash
 # From the project root
-mkdir -p backend/.env  # Create directory if it doesn't exist
+mkdir -p backend  # Make sure backend directory exists
 
 if [ -f backend/.env ]; then
   echo "*** Warning: Backend .env file already exists. Please merge the contents manually. ***"

--- a/docs/backend/setup/details/step2-environment-configuration.md
+++ b/docs/backend/setup/details/step2-environment-configuration.md
@@ -89,27 +89,38 @@ Create a file named `.env.sample` in the project root directory with the followi
 ```
 # Django settings
 DJANGO_ENV=local  # Options: local, test, production
-DJANGO_SETTINGS_MODULE=hellobirdie.settings.local
+# Do not set DJANGO_SETTINGS_MODULE here - it's handled by settings/__init__.py
 DJANGO_SECRET_KEY=your-secret-key-here
 DJANGO_DEBUG=True
 
-# Database settings - Docker
+# Database settings - Hybrid Approach
+# For Docker environment (used when IN_DOCKER=True)
 DATABASE_URL=postgres://postgres:postgres@db:5432/hellobirdie
+DOCKER_DB_HOST_PORT=5433  # The host port when running in Docker
 
-# Database settings - Local Development
+# For Local Development (default when IN_DOCKER is not set)
 LOCAL_DATABASE_URL=postgres://hellobirdie_user:hellobirdie_password@localhost:5432/hellobirdie
 
-# Individual Database Components (used by some Django settings)
+# Individual Database Components (used in some Django settings configurations)
+# These values are used for local development by default
 POSTGRES_DB=hellobirdie
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_HOST=localhost
+POSTGRES_USER=hellobirdie_user  # Updated to match local development user
+POSTGRES_PASSWORD=hellobirdie_password  # Updated to match local development password
+POSTGRES_HOST=localhost  # For local development
 POSTGRES_PORT=5432
 POSTGRES_TEST_DB=test_hellobirdie
 
+# Time zone setting (consistent with Docker configuration)
+TZ=UTC
+
 # API settings
 ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# Updated to include Vite's default port 5173 as mentioned in our diagrams
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173
+
+# Environment detection (used in settings to determine which database URL to use)
+# This is automatically set to True in the Docker container via docker-compose.yml
+# IN_DOCKER=True
 ```
 
 ### 2. Create or Update Your Local Environment File

--- a/docs/backend/setup/details/step5-settings-structure-refactoring.md
+++ b/docs/backend/setup/details/step5-settings-structure-refactoring.md
@@ -169,18 +169,18 @@ else:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("POSTGRES_DB", "hellobirdie"),
-            "USER": os.environ.get("POSTGRES_USER",
-                      "postgres" if IN_DOCKER else "hellobirdie_user"),
-            "PASSWORD": os.environ.get("POSTGRES_PASSWORD",
-                         "postgres" if IN_DOCKER else "hellobirdie_password"),
-            "HOST": os.environ.get("POSTGRES_HOST", "db" if IN_DOCKER else "localhost"),
-            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+            "NAME": os.environ.get("LOCAL_POSTGRES_DB", "hellobirdie") if not IN_DOCKER else os.environ.get("POSTGRES_DB", "hellobirdie"),
+            "USER": os.environ.get("LOCAL_POSTGRES_USER", "hellobirdie_user") if not IN_DOCKER else os.environ.get("POSTGRES_USER", "postgres"),
+            "PASSWORD": os.environ.get("LOCAL_POSTGRES_PASSWORD", "hellobirdie_password") if not IN_DOCKER else os.environ.get("POSTGRES_PASSWORD", "postgres"),
+            "HOST": os.environ.get("LOCAL_POSTGRES_HOST", "localhost") if not IN_DOCKER else os.environ.get("POSTGRES_HOST", "db"),
+            "PORT": os.environ.get("LOCAL_POSTGRES_PORT", "5432") if not IN_DOCKER else os.environ.get("POSTGRES_PORT", "5432"),
         }
     }
 ```
 
 ### 4. Create Test Settings (test.py)
+
+**Note**: This file is created from scratch during the settings refactoring process, as it wasn't part of the minimal settings structure:
 
 Create a file named `test.py` in the `backend/hellobirdie/settings/` directory with the following content:
 
@@ -232,13 +232,11 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': os.environ.get('POSTGRES_TEST_DB', 'hellobirdie_test'),
-            'USER': os.environ.get('POSTGRES_USER',
-                    'postgres' if IN_DOCKER else 'hellobirdie_user'),
-            'PASSWORD': os.environ.get('POSTGRES_PASSWORD',
-                       'postgres' if IN_DOCKER else 'hellobirdie_password'),
-            'HOST': os.environ.get('POSTGRES_HOST', 'db' if IN_DOCKER else 'localhost'),
-            'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+            'NAME': os.environ.get('POSTGRES_TEST_DB', 'test_hellobirdie') if IN_DOCKER else os.environ.get('LOCAL_POSTGRES_DB', 'hellobirdie_test'),
+            'USER': os.environ.get('LOCAL_POSTGRES_USER', 'hellobirdie_user') if not IN_DOCKER else os.environ.get('POSTGRES_USER', 'postgres'),
+            'PASSWORD': os.environ.get('LOCAL_POSTGRES_PASSWORD', 'hellobirdie_password') if not IN_DOCKER else os.environ.get('POSTGRES_PASSWORD', 'postgres'),
+            'HOST': os.environ.get('LOCAL_POSTGRES_HOST', 'localhost') if not IN_DOCKER else os.environ.get('POSTGRES_HOST', 'db'),
+            'PORT': os.environ.get('LOCAL_POSTGRES_PORT', '5432') if not IN_DOCKER else os.environ.get('POSTGRES_PORT', '5432'),
         }
     }
 

--- a/docs/backend/setup/details/step5-settings-structure-refactoring.md
+++ b/docs/backend/setup/details/step5-settings-structure-refactoring.md
@@ -4,7 +4,7 @@ This guide provides detailed instructions for refactoring the Django settings st
 
 ## Overview
 
-In Step 2 (Environment Configuration), we created a minimal settings structure to support Docker testing. Now we'll enhance and properly organize this structure following best practices.
+In Step 3 (Django Project Initialization), we created a minimal settings structure to support Docker testing. Now we'll enhance and properly organize this structure following best practices.
 
 ## Split Settings Approach
 
@@ -12,9 +12,9 @@ For the HelloBirdie project, we're using a split settings approach with three ma
 
 ```
 settings/
-├── __init__.py  # Settings loader (already created in Step 2)
+├── __init__.py  # Settings loader (already created in Step 3)
 ├── base.py      # Common settings
-├── local.py     # Development settings (enhance the minimal version from Step 2)
+├── local.py     # Development settings (enhance the minimal version from Step 3)
 └── test.py      # Test-specific settings
 ```
 
@@ -48,7 +48,7 @@ settings/
 
 ### 1. Enhance the Minimal Settings Structure
 
-The directory structure should already exist from Step 2. If not, create it with:
+The directory structure should already exist from Step 3. If not, create it with:
 
 ```bash
 # From the backend directory
@@ -137,11 +137,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 ### 3. Enhance Local Settings (local.py)
 
-Enhance the minimal `local.py` file created in Step 2 with more complete development-specific settings:
+**Note**: This will completely replace the minimal version of `local.py` created in Step 3 with a more comprehensive implementation that better handles database connections for our hybrid workflow:
 
 ```python
 # hellobirdie/settings/local.py
 import os
+import dj_database_url
 from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -149,18 +150,34 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
-# Database
-# Use PostgreSQL for local development
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('POSTGRES_DB', 'hellobirdie'),
-        'USER': os.environ.get('POSTGRES_USER', 'postgres'),
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'postgres'),
-        'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
-        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+# Check if we're running in a Docker environment - normalize to bool
+IN_DOCKER = os.environ.get("IN_DOCKER", "").lower() == "true"
+
+# Database configuration with hybrid approach
+# 1. In Docker: Use DATABASE_URL
+# 2. Local with URL: Use LOCAL_DATABASE_URL
+# 3. Fallback: Use individual parameters
+
+if IN_DOCKER and os.environ.get("DATABASE_URL"):
+    # Docker environment - use DATABASE_URL
+    DATABASES = {"default": dj_database_url.parse(os.environ.get("DATABASE_URL"))}
+elif not IN_DOCKER and os.environ.get("LOCAL_DATABASE_URL"):
+    # Local environment with DATABASE_URL specified
+    DATABASES = {"default": dj_database_url.parse(os.environ.get("LOCAL_DATABASE_URL"))}
+else:
+    # Fallback to individual PostgreSQL configuration parameters
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.environ.get("POSTGRES_DB", "hellobirdie"),
+            "USER": os.environ.get("POSTGRES_USER",
+                      "postgres" if IN_DOCKER else "hellobirdie_user"),
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD",
+                         "postgres" if IN_DOCKER else "hellobirdie_password"),
+            "HOST": os.environ.get("POSTGRES_HOST", "db" if IN_DOCKER else "localhost"),
+            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        }
     }
-}
 ```
 
 ### 4. Create Test Settings (test.py)
@@ -170,24 +187,60 @@ Create a file named `test.py` in the `backend/hellobirdie/settings/` directory w
 ```python
 # hellobirdie/settings/test.py
 import os
+import dj_database_url
 from .base import *
 
 DEBUG = False
 
-# Check if we're running in a Docker environment
-IN_DOCKER = os.environ.get('IN_DOCKER', False)
+# Normalize IN_DOCKER to bool
+IN_DOCKER = os.environ.get('IN_DOCKER', '').lower() == 'true'
 
-# Use PostgreSQL for tests to match production
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('POSTGRES_DB', 'test_hellobirdie'),
-        'USER': os.environ.get('POSTGRES_USER', 'postgres'),
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'postgres'),
-        'HOST': os.environ.get('POSTGRES_HOST', 'db' if IN_DOCKER else 'localhost'),
-        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+# Test database configuration with hybrid approach, similar to local.py
+# 1. In Docker: Use DATABASE_URL with test suffix
+# 2. Local with URL: Use LOCAL_DATABASE_URL with test suffix
+# 3. Fallback: Use individual parameters with test database name
+
+# Function to add test suffix to database URL
+def get_test_db_url(url):
+    if not url:
+        return None
+    # Add _test suffix to database name in the URL
+    from urllib.parse import urlparse, parse_qs
+    parsed = urlparse(url)
+    path = parsed.path
+    if path.startswith('/'):
+        path = f"{path}_test"
+    else:
+        path = f"/{path}_test"
+
+    # Reconstruct URL with modified path
+    parts = list(parsed)
+    parts[2] = path  # Update path component
+    return urlunparse(parts)
+
+# Prioritize URLs over individual settings
+if IN_DOCKER and os.environ.get('DATABASE_URL'):
+    # Create test version of Docker database
+    test_db_url = get_test_db_url(os.environ.get('DATABASE_URL'))
+    DATABASES = {'default': dj_database_url.parse(test_db_url)}
+elif not IN_DOCKER and os.environ.get('LOCAL_DATABASE_URL'):
+    # Create test version of local database
+    test_db_url = get_test_db_url(os.environ.get('LOCAL_DATABASE_URL'))
+    DATABASES = {'default': dj_database_url.parse(test_db_url)}
+else:
+    # Fallback to individual PostgreSQL configuration parameters
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.environ.get('POSTGRES_TEST_DB', 'hellobirdie_test'),
+            'USER': os.environ.get('POSTGRES_USER',
+                    'postgres' if IN_DOCKER else 'hellobirdie_user'),
+            'PASSWORD': os.environ.get('POSTGRES_PASSWORD',
+                       'postgres' if IN_DOCKER else 'hellobirdie_password'),
+            'HOST': os.environ.get('POSTGRES_HOST', 'db' if IN_DOCKER else 'localhost'),
+            'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+        }
     }
-}
 
 # Faster password hashing for tests
 PASSWORD_HASHERS = [
@@ -261,7 +314,7 @@ POSTGRES_PORT=5432
 > ```bash
 > # Check if .gitignore covers nested .env files
 > grep -E '\.env$|backend/\.env' .gitignore
-> 
+>
 > # If not found, add it to .gitignore
 > echo 'backend/.env' >> .gitignore
 > ```

--- a/docs/backend/setup/hybrid-backend-setup-guide.md
+++ b/docs/backend/setup/hybrid-backend-setup-guide.md
@@ -108,7 +108,7 @@ Implement a health check endpoint following TDD principles. For detailed impleme
 
 ### 5. Settings Structure Refactoring (REFACTOR Phase)
 
-Follow the [Step 5: Settings Structure Refactoring](./details/step5-settings-structure-refactoring.md) guide to properly refactor the minimal settings structure created in Step 2:
+Follow the [Step 5: Settings Structure Refactoring](./details/step5-settings-structure-refactoring.md) guide to properly refactor the minimal settings structure created in Step 3:
 
 - Expand the settings directory structure
   ```


### PR DESCRIPTION
## Changes

This pull request aligns the backend environment configuration with the project's documentation standards, implementing a more robust and maintainable setup.

- Implements a dual `.env` file strategy:
  - Root `.env` for shared Docker/infrastructure settings.
  - `backend/.env` for Django-specific settings.
- Updates [docker-compose.yml](cci:7://file:///home/john/Projects/hellobirdie/docker-compose.yml:0:0-0:0) to use `env_file` to load backend-specific variables, removing hardcoded values.
- Refactors [settings/local.py](cci:7://file:///home/john/Projects/hellobirdie/backend/hellobirdie/settings/local.py:0:0-0:0) to intelligently detect the environment (Docker vs. local) and load the correct database configuration.
- Standardizes the health check endpoint to `api/health-check/` for better consistency and RESTful naming conventions.
- Includes corresponding documentation updates from the `docs/backend-setup-alignment` branch.

## Type of Change

- [x] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation

## Testing

- [x] Unit tests for the health check endpoint were updated and pass successfully.
- [x] Manual testing with `curl` confirms the `api/health-check/` endpoint returns a `200 OK` status.
- [x] Tests were run in both the default (`local`) and [test](cci:1://file:///home/john/Projects/hellobirdie/backend/api/tests/test_health.py:6:4-13:48) environments (`DJANGO_ENV=test`) to verify the new settings logic.