### PR TITLE
feat: implement split settings structure with base, local, and test settings

### DIFF
--- a/backend/hellobirdie/settings/__init__.py
+++ b/backend/hellobirdie/settings/__init__.py
@@ -1,0 +1,11 @@
+import os
+
+# Default to local settings if DJANGO_ENV is not set
+env = os.environ.get("DJANGO_ENV", "local")
+
+if env == "production":
+    from .production import *
+elif env == "test":
+    from .test import *
+else:
+    from .local import *

--- a/backend/hellobirdie/settings/base.py
+++ b/backend/hellobirdie/settings/base.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+# Build paths inside the project
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "django-insecure-default-key-for-dev")
+
+# Application definition
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    # Local apps
+    "api",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "hellobirdie.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "hellobirdie.wsgi.application"
+
+# Password validation
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
+
+# Internationalization
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+# Static files
+STATIC_URL = "static/"
+
+# Default primary key field type
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/backend/hellobirdie/settings/local.py
+++ b/backend/hellobirdie/settings/local.py
@@ -1,93 +1,19 @@
-"""
-Temporary local development settings for hellobirdie project.
-This will be properly refactored in Step 5 (Settings Structure Refactoring).
-"""
-
 import os
-import sys
 import dj_database_url
-from pathlib import Path
-
-# Get the parent directory to access the main settings file
-parent_dir = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(parent_dir.parent))
-
-# Define BASE_DIR for database path
-BASE_DIR = parent_dir.parent
-
-# Import all settings from the main settings file
-from hellobirdie.settings import *
-
-# Root URL configuration
-ROOT_URLCONF = "hellobirdie.urls"
-
-# Security settings
-SECRET_KEY = os.environ.get(
-    "DJANGO_SECRET_KEY", "django-insecure-development-key-for-testing-only"
-)
+from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# Allow all hosts in local development
-ALLOWED_HOSTS = ["*"]
-
-# Static files (CSS, JavaScript, Images)
-STATIC_URL = "/static/"
-
-# Time zone settings
-TIME_ZONE = "UTC"
-USE_TZ = True
-
-# Add the api app to INSTALLED_APPS
-INSTALLED_APPS = [
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    "api",
-]
-
-# Templates configuration required for admin
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.template.context_processors.debug",
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
-            ],
-        },
-    },
-]
-
-# Middleware configuration required for admin
-MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-]
-
-# Database configuration
-# Use PostgreSQL for both local development and Docker environments
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 # Check if we're running in a Docker environment - normalize to bool
 IN_DOCKER = os.environ.get("IN_DOCKER", "").lower() == "true"
 
-# Database URL handling logic
-# 1. If in Docker, use DATABASE_URL from backend/.env
-# 2. If not in Docker but LOCAL_DATABASE_URL exists, use that from backend/.env
-# 3. Otherwise fallback to individual environment variables
+# Database configuration with hybrid approach
+# 1. In Docker: Use DATABASE_URL
+# 2. Local with URL: Use LOCAL_DATABASE_URL
+# 3. Fallback: Use individual parameters
 
 if IN_DOCKER and os.environ.get("DATABASE_URL"):
     # Docker environment - use DATABASE_URL

--- a/backend/hellobirdie/settings/test.py
+++ b/backend/hellobirdie/settings/test.py
@@ -1,0 +1,87 @@
+import os
+import dj_database_url
+from .base import *
+
+DEBUG = False
+
+# Normalize IN_DOCKER to bool
+IN_DOCKER = os.environ.get("IN_DOCKER", "").lower() == "true"
+
+# Test database configuration with hybrid approach, similar to local.py
+# 1. In Docker: Use DATABASE_URL with test suffix
+# 2. Local with URL: Use LOCAL_DATABASE_URL with test suffix
+# 3. Fallback: Use individual parameters with test database name
+
+
+# Function to add test suffix to database URL
+def get_test_db_url(url):
+    if not url:
+        return None
+    # Add _test suffix to database name in the URL
+    from urllib.parse import urlparse, urlunparse, parse_qs
+
+    parsed = urlparse(url)
+    path = parsed.path
+    if path.startswith("/"):
+        path = f"{path}_test"
+    else:
+        path = f"/{path}_test"
+
+    # Reconstruct URL with modified path
+    parts = list(parsed)
+    parts[2] = path  # Update path component
+    return urlunparse(parts)
+
+
+# Prioritize URLs over individual settings
+if IN_DOCKER and os.environ.get("DATABASE_URL"):
+    # Create test version of Docker database
+    test_db_url = get_test_db_url(os.environ.get("DATABASE_URL"))
+    DATABASES = {"default": dj_database_url.parse(test_db_url)}
+elif not IN_DOCKER and os.environ.get("LOCAL_DATABASE_URL"):
+    # Create test version of local database
+    test_db_url = get_test_db_url(os.environ.get("LOCAL_DATABASE_URL"))
+    DATABASES = {"default": dj_database_url.parse(test_db_url)}
+else:
+    # Fallback to individual PostgreSQL configuration parameters
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": (
+                os.environ.get("POSTGRES_TEST_DB", "test_hellobirdie")
+                if IN_DOCKER
+                else os.environ.get("LOCAL_POSTGRES_DB", "hellobirdie_test")
+            ),
+            "USER": (
+                os.environ.get("LOCAL_POSTGRES_USER", "hellobirdie_user")
+                if not IN_DOCKER
+                else os.environ.get("POSTGRES_USER", "postgres")
+            ),
+            "PASSWORD": (
+                os.environ.get("LOCAL_POSTGRES_PASSWORD", "hellobirdie_password")
+                if not IN_DOCKER
+                else os.environ.get("POSTGRES_PASSWORD", "postgres")
+            ),
+            "HOST": (
+                os.environ.get("LOCAL_POSTGRES_HOST", "localhost")
+                if not IN_DOCKER
+                else os.environ.get("POSTGRES_HOST", "db")
+            ),
+            "PORT": (
+                os.environ.get("LOCAL_POSTGRES_PORT", "5432")
+                if not IN_DOCKER
+                else os.environ.get("POSTGRES_PORT", "5432")
+            ),
+        }
+    }
+
+# Faster password hashing for tests
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
+
+# Disable logging during tests
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": True,
+}


### PR DESCRIPTION
Split Django Settings Structure for Environment Separation

Implements a modular Django settings structure that separates configuration by environment:
- base.py: Common settings shared across all environments
- local.py: Development-specific settings with hybrid local/Docker support
- test.py: Test environment settings with dedicated test database configurations
- __init__.py: Dynamic settings loader based on DJANGO_ENV variable

This refactor improves code organization, simplifies testing across environments, and prepares the codebase for future production deployment while maintaining our hybrid local/Docker workflow.