### PR TITLE
feat: remap Docker backend port to 8001 to avoid conflicts with local server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./backend:/app
     ports:
-      - "8000:8000"
+      - "8001:8000"  # Using port 8001 on host to avoid conflicts with local development server
     environment:
       - DJANGO_ENV=local # Must match the environment name used in settings/__init__.py
       # Do not set DJANGO_SETTINGS_MODULE here - allow __init__.py to handle it based on DJANGO_ENV


### PR DESCRIPTION
Remap Docker Backend Port to Avoid Conflicts with Local Server

## Changes
- Changed Docker Compose backend port mapping from 8000:8000 to 8001:8000
- This allows running both local Django server and Docker containers simultaneously

## Testing Done
- Verified Docker containers start correctly with new port configuration
- Confirmed health check endpoint is accessible at http://localhost:8001/api/health-check/

## Benefits
- Eliminates "port already in use" errors when switching between environments
- Enables parallel development in both local and Docker environments
- Follows the same pattern used for PostgreSQL port remapping