### PR TITLE
docs: consolidate PR guidance; add PR template and link from docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Changes
+
+- Describe the key changes introduced by this PR
+
+## Type of Change
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Test-only
+
+## API Contract
+
+- [ ] This PR adds/changes an API endpoint
+- [ ] Contract updated (path): `docs/backend/api/recordings-search-contract.md`
+- [ ] API Contract reviewed and approved by frontend reviewer
+- [ ] Breaking change? If yes, bump API version path (e.g., `/api/v2/...`) and document migration notes
+- [ ] Error codes and response `meta` fields remain consistent OR changes documented in the contract
+- [ ] TDD tests updated/added to reflect contract
+
+## Testing
+
+- [ ] Unit tests added/updated
+- [ ] Manual testing completed
+- [ ] Pagination verified (page/perPage/pagesFetched/hasNextPage)
+- [ ] Caching behavior verified (servedFromCache/isStale/refreshedAt)
+
+## Security & Privacy
+
+- [ ] No secrets (API keys) exposed
+- [ ] CORS allowlist verified (no wildcards in production)
+- [ ] Logs do not contain precise user coordinates or secrets
+
+## Performance & Observability
+
+- [ ] perPage/page cap impacts considered; latency acceptable
+- [ ] Cache keys and TTL implications considered
+- [ ] Metrics/alerts updated if applicable
+
+## Screenshots / UI notes (if applicable)
+
+- Include screenshots or notes for UI changes
+
+## Additional Notes
+
+- Anything else reviewers should know

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,15 @@
   - `feature/add-map-clustering`
   - `fix/audio-playback-mobile`
 
-### Pull Request Process
+### Change and Pull Request Workflow
+
+Steps 1–3 prepare your change; steps 4–6 cover opening and completing the PR.
 
 1. Create a feature branch from `main`
 2. Implement changes with appropriate tests
 3. Run the local test suite
 4. Create a pull request using the PR template
+   - Template: [Pull Request Template](/.github/pull_request_template.md)
 5. Address review feedback
 6. Merge after approval
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ New team members should start with:
 4. [Backend Setup Guide](./backend/setup/hybrid-backend-setup-guide.md) - Set up the backend locally
 5. [Docker Guide](./project/docker-guide.md) - Learn Docker for verification and testing
 6. [API Endpoints](./backend/api/endpoints.md) - Explore available API endpoints
+7. [Contributing Guidelines](../CONTRIBUTING.md) - Branch naming, PR process, and review checklist
 
 ## Development Principles
 

--- a/docs/backend/setup/guides/feature-setup-guide.md
+++ b/docs/backend/setup/guides/feature-setup-guide.md
@@ -59,7 +59,7 @@ This guide builds upon the backend setup and provides detailed steps for impleme
 - Update documentation
 - Check code against style guide
 - Verify mobile responsiveness
-- Complete PR template
+- Complete PR template: [Pull Request Template](/.github/pull_request_template.md)
 
 ### 5. Deployment Considerations
 


### PR DESCRIPTION
- Add repo-wide PR template

- Link template from CONTRIBUTING and feature setup guide

- Add Contributing link to docs index